### PR TITLE
added the marker feature

### DIFF
--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/AbstractJsonLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/AbstractJsonLogger.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonObject;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.slf4j.MDC;
+import org.slf4j.Marker;
 
 import java.text.Format;
 import java.util.List;
@@ -190,6 +191,14 @@ public abstract class AbstractJsonLogger implements JsonLogger {
 
   @Override
   public abstract void log();
+
+  @Override
+  public abstract void log(Marker marker);
+
+  protected String formatMessage(String marker, String level) {
+    jsonObject.add("marker", gson.toJsonTree(marker));
+    return formatMessage(level);
+  }
 
   protected String formatMessage(String level) {
 

--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/DebugLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/DebugLogger.java
@@ -21,6 +21,7 @@ package com.savoirtech.logging.slf4j.json.logger;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.time.FastDateFormat;
+import org.slf4j.Marker;
 
 public class DebugLogger extends AbstractJsonLogger {
 
@@ -33,6 +34,11 @@ public class DebugLogger extends AbstractJsonLogger {
   @Override
   public void log() {
     slf4jLogger.debug(formatMessage(LOG_LEVEL));
+  }
+
+  @Override
+  public void log(Marker marker) {
+    slf4jLogger.debug(marker, formatMessage(marker.getName(), LOG_LEVEL));
   }
 
   public String toString() {

--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/ErrorLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/ErrorLogger.java
@@ -21,6 +21,7 @@ package com.savoirtech.logging.slf4j.json.logger;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.time.FastDateFormat;
+import org.slf4j.Marker;
 
 public class ErrorLogger extends AbstractJsonLogger {
 
@@ -33,6 +34,11 @@ public class ErrorLogger extends AbstractJsonLogger {
   @Override
   public void log() {
     slf4jLogger.error(formatMessage(LOG_LEVEL));
+  }
+
+  @Override
+  public void log(Marker marker) {
+    slf4jLogger.error(marker, formatMessage(marker.getName(), LOG_LEVEL));
   }
 
   public String toString() {

--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/InfoLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/InfoLogger.java
@@ -21,6 +21,7 @@ package com.savoirtech.logging.slf4j.json.logger;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.time.FastDateFormat;
+import org.slf4j.Marker;
 
 public class InfoLogger extends AbstractJsonLogger {
 
@@ -33,6 +34,11 @@ public class InfoLogger extends AbstractJsonLogger {
   @Override
   public void log() {
     slf4jLogger.info(formatMessage(LOG_LEVEL));
+  }
+
+  @Override
+  public void log(Marker marker) {
+    slf4jLogger.info(marker, formatMessage(marker.getName(), LOG_LEVEL));
   }
 
   public String toString() {

--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/JsonLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/JsonLogger.java
@@ -19,6 +19,7 @@
 package com.savoirtech.logging.slf4j.json.logger;
 
 import com.google.gson.JsonElement;
+import org.slf4j.Marker;
 
 import java.util.List;
 import java.util.Map;
@@ -115,4 +116,6 @@ public interface JsonLogger {
    * Log the formatted message
    */
   void log();
+
+  void log(Marker marker);
 }

--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/NoopLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/NoopLogger.java
@@ -19,6 +19,7 @@
 package com.savoirtech.logging.slf4j.json.logger;
 
 import com.google.gson.JsonElement;
+import org.slf4j.Marker;
 
 import java.util.List;
 import java.util.Map;
@@ -86,6 +87,11 @@ public class NoopLogger implements JsonLogger {
 
   @Override
   public void log() {
+
+  }
+
+  @Override
+  public void log(Marker marker) {
 
   }
 

--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/TraceLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/TraceLogger.java
@@ -21,6 +21,7 @@ package com.savoirtech.logging.slf4j.json.logger;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.time.FastDateFormat;
+import org.slf4j.Marker;
 
 public class TraceLogger extends AbstractJsonLogger {
 
@@ -33,6 +34,11 @@ public class TraceLogger extends AbstractJsonLogger {
   @Override
   public void log() {
     slf4jLogger.trace(formatMessage(LOG_LEVEL));
+  }
+
+  @Override
+  public void log(Marker marker) {
+    slf4jLogger.trace(marker, formatMessage(marker.getName(), LOG_LEVEL));
   }
 
   public String toString() {

--- a/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/WarnLogger.java
+++ b/slf4j-json-logger/src/main/java/com/savoirtech/logging/slf4j/json/logger/WarnLogger.java
@@ -21,6 +21,7 @@ package com.savoirtech.logging.slf4j.json.logger;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.time.FastDateFormat;
+import org.slf4j.Marker;
 
 public class WarnLogger extends AbstractJsonLogger {
 
@@ -33,6 +34,11 @@ public class WarnLogger extends AbstractJsonLogger {
   @Override
   public void log() {
     slf4jLogger.warn(formatMessage(LOG_LEVEL));
+  }
+
+  @Override
+  public void log(Marker marker) {
+    slf4jLogger.warn(marker, formatMessage(marker.getName(), LOG_LEVEL));
   }
 
   public String toString() {

--- a/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/AbstractJsonLoggerExceptionTest.java
+++ b/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/AbstractJsonLoggerExceptionTest.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.MDC;
+import org.slf4j.Marker;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -64,6 +65,12 @@ public class AbstractJsonLoggerExceptionTest {
       public void log() {
         logMessage = formatMessage("INFO");
       }
+
+      @Override
+      public void log(Marker marker) {
+        logMessage = formatMessage(marker.getName(), "INFO");
+      }
+
     };
   }
 

--- a/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/AbstractJsonLoggerTest.java
+++ b/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/AbstractJsonLoggerTest.java
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -58,6 +60,12 @@ public class AbstractJsonLoggerTest {
       public void log() {
         logMessage = formatMessage("INFO");
       }
+
+      @Override
+      public void log(Marker marker) {
+        logMessage = formatMessage(marker.getName(), "INFO");
+      }
+
     };
   }
 
@@ -195,5 +203,11 @@ public class AbstractJsonLoggerTest {
     // should not throw a null pointer
     assert (!logMessage.contains("java.lang.NullPointerException"));
     assert (logMessage.contains("\"nullValue\":null"));
+  }
+
+  @Test
+  public void markerIsUsed() {
+    logger.log(MarkerFactory.getMarker("TEST"));
+    assert (logMessage.contains("\"marker\":\"TEST\""));
   }
 }

--- a/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/StackTest.java
+++ b/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/StackTest.java
@@ -91,7 +91,7 @@ public class StackTest {
   public void stack() {
     Class1 class1 = new Class1();
     class1.logMe();
-    assert(logMessage.contains("\"stacktrace\":\"com.savoirtech.logging.slf4j.json.logger.StackTest$Class4.logMe(StackTest.java:79)\\n\\tat com.savoirtech.logging.slf4j.json.logger.StackTest$Class3.logMe(StackTest.java:69)\\n\\tat com.savoirtech.logging.slf4j.json.logger.StackTest$Class2.logMe(StackTest.java:57)\\n\\tat com.savoirtech.logging.slf4j.json.logger.StackTest$Class1.logMe(StackTest.java:45)"));
+    assert(logMessage.contains("\"stacktrace\":\"com.savoirtech.logging.slf4j.json.logger.StackTest$Class4.logMe(StackTest.java:86)\\n\\tat com.savoirtech.logging.slf4j.json.logger.StackTest$Class3.logMe(StackTest.java:76)\\n\\tat com.savoirtech.logging.slf4j.json.logger.StackTest$Class2.logMe(StackTest.java:64)\\n\\tat com.savoirtech.logging.slf4j.json.logger.StackTest$Class1.logMe(StackTest.java:52)"));
   }
 
 }

--- a/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/StackTest.java
+++ b/slf4j-json-logger/src/test/java/com/savoirtech/logging/slf4j/json/logger/StackTest.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.time.FastDateFormat;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.Marker;
 
 public class StackTest {
   private AbstractJsonLogger logger;
@@ -31,6 +32,12 @@ public class StackTest {
       public void log() {
         logMessage = formatMessage("INFO");
       }
+
+      @Override
+      public void log(Marker marker) {
+        logMessage = formatMessage(marker.getName(), "INFO");
+      }
+
     };
   }
 


### PR DESCRIPTION
Dear savoirtech,

You have an awesome library but it was missing the marker feature from the slf4j library. These markers can be used for filtering the log messages. 

We use these markers in our project to set the type of messages and decide to which component of our system it needs to be send. It is also used to mark that these log messages are already formatted in json.

Kind regards, Boris Smidt